### PR TITLE
Probe pin invert FIX

### DIFF
--- a/grbl/probe.c
+++ b/grbl/probe.c
@@ -22,7 +22,7 @@
 
 
 // Inverts the probe pin state depending on user settings and probing cycle mode.
-uint8_t probe_invert_mask;
+uint16_t probe_invert_mask;
 
 
 // Probe pin initialization routine.


### PR DESCRIPTION
> $6=1 (probe pin invert, bool)

Not working. 
Because probe_invert_mask 
uint8_t but assigned uint16_t value